### PR TITLE
fix: download commond in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN apt-get update \
 RUN echo "In memory node version: ${LATEST_RELEASE}"
 
 # Download the release version specified by the build argument
-RUN curl -s echo "https://api.github.com/repos/matter-labs/era-test-node/releases/tags/${LATEST_RELEASE}" | \
+RUN curl -s "https://api.github.com/repos/matter-labs/era-test-node/releases/tags/${LATEST_RELEASE}" | \
   jq -r '.assets[] | select(.name | contains("x86_64-unknown-linux-gnu")) | .browser_download_url' | \
   head -n 1 | xargs -I {} curl -L -o era_test_node.tar.gz {}
 


### PR DESCRIPTION
# What :computer: 
* remove `echo`  to fix download commond in Dockerfile
  * `RUN curl -s echo "https://api.github.com/...` -> `RUN curl -s "https://api.github.com/...`

# Why :hand:
* Using `curl -s  echo` can cause the `jq -r` command to fail, but removing the echo command allows it to execute correctly. The current version of the Dockerfile will cause the build to fail; after modification, it can be built successfully.

```sh
# will faild with echo
curl -s echo "https://api.github.com/repos/matter-labs/era-test-node/releases/tags/v0.1.0-alpha.19" | jq -r
jq: parse error: Invalid numeric literal at line 1, column 10

# query successfully
curl -s "https://api.github.com/repos/matter-labs/era-test-node/releases/tags/v0.1.0-alpha.19" | jq -r
{
  "url": "https://api.github.com/repos/matter-labs/era-test-node/releases/147603455",
  "assets_url": "https://api.github.com/repos/matter-labs/era-test-node/releases/147603455/assets",
  "upload_url": "https://uploads.github.com/repos/matter-labs/era-test-node/releases/147603455/assets{?name,label}",
  ...
}
```

# Evidence :camera:
<img width="725" alt="image" src="https://github.com/matter-labs/zkcli-in-memory-node/assets/19644290/cd1ca82a-1359-4be1-bbce-3fdede83de68">


**Local Development Environment**:

Operating System: macOs Ventura 13.3
Node.js Version: 20.11.0
npm Version: 10.5.0
Docker Version: 24.0.2
curl Version: 7.87.0
jq Version: jq-1.7.1
