### PR TITLE
Update Rich accounts url

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -60,7 +60,7 @@ export default class SetupModule extends ModuleNode<ModuleConfig> {
         list: [
           `Chain ID: ${this.nodeInfo.id}`,
           `RPC URL: ${this.nodeInfo.rpcUrl}`,
-          "Rich accounts: https://docs.zksync.io/build/test-and-debug/in-memory-node#pre-configured-rich-wallets",
+          "Rich accounts: https://docs.zksync.io/zksync-era/tooling/local-setup/in-memory-node#pre-configured-rich-wallets",
         ],
       },
       chalk.yellow("Note: every restart will necessitate a reset of MetaMask's cached account data"),


### PR DESCRIPTION
fix Rich accounts url

# What :computer: 
* Update Rich accounts url

# Why :hand:
* zksync has updated their documents, the original link is no longer accessible. 

# Evidence :camera:
Old url
<img width="1225" alt="Screenshot 2024-12-10 at 14 41 22" src="https://github.com/user-attachments/assets/89afd222-6c31-483d-9a37-26ede9a3ebc9">

New url
<img width="1002" alt="Screenshot 2024-12-10 at 14 42 29" src="https://github.com/user-attachments/assets/879a4eca-5950-473b-af60-262799de0cdf">


# Notes :memo:
